### PR TITLE
Pass image property when diagramIdentifier changed

### DIFF
--- a/Classes/DiagramNodeHandler.php
+++ b/Classes/DiagramNodeHandler.php
@@ -45,6 +45,7 @@ class DiagramNodeHandler
         if ($sourceDiagramNode) {
             $node->setProperty('diagramSource', $sourceDiagramNode->getProperty('diagramSource'));
             $node->setProperty('diagramSvgText', $sourceDiagramNode->getProperty('diagramSvgText'));
+            $node->setProperty('image', $sourceDiagramNode->getProperty('image'));
         }
     }
 }


### PR DESCRIPTION
Fixes creating new image when a diagram-id is set and then the diagram editor is opened and the changes is saved.